### PR TITLE
add method="post" flag to post_form template

### DIFF
--- a/beer_me/templates/post_form.html
+++ b/beer_me/templates/post_form.html
@@ -5,7 +5,7 @@
 </head>
 <body>
     <h1>Add Post</h1>
-    <form action="/addpost">
+    <form action="/addpost" method="post">
         <label>Post Title</label>
         {{ postform.title }}
         <label>Post Text</label>


### PR DESCRIPTION
Fixes viewing /posts route, unintentionally broken in previous PR